### PR TITLE
Release v1.17.1-rc.1: Portada/Hero estables + Edición de Álbumes (UI + test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Un portfolio elegante y moderno para modelos de moda, con sistema de gestión de
 - Edición desde Admin: modal con campos y validación/preview de slug.
 - Página pública por álbum: `/album/:slug` reutilizando la vista pública y filtrando por slug.
 
+### 🖼️ Portada/Hero – Persistencia y estabilidad
+- Portada única y sincronizada con KV (`/api/cover`), UI con borde azul en Admin para la seleccionada.
+- Home y Admin con auto-refresh suave cada 30s para mantenerse en línea con KV.
+- `hero-loader` prioriza URL pública de Blob; se eliminó cualquier fallback a `/uploads` para Vercel.
+
 ### 🔜 Próximo
 - RUM (TTFB/LCP/CLS), navegación lightbox (`next/prev`, dwell), reordenamientos (galería/álbumes), top listas (imágenes/álbumes) y selector 7/30 días.
 
@@ -56,6 +61,15 @@ Un portfolio elegante y moderno para modelos de moda, con sistema de gestión de
 ### 🧭 Gitflow (backup/RC)
 - Ramas `release/*` funcionan como respaldo congelado (Release Candidate).
 - Creadas: `release/v1.17.0` (actual), `release/v1.16.0`, `release/v1.15.0`, `release/v1.14.0`, `release/v1.13.0`.
+
+#### 📦 Cómo crear una Release Candidate nueva
+```zsh
+git checkout develop
+git pull origin develop
+git checkout -b release/v1.17.0-rc.1
+git push -u origin release/v1.17.0-rc.1
+```
+Luego validar en Vercel/CI y, al finalizar, mergear a `main` y taggear.
 
 #### 🔀 Ramas activas hoy
 - `main` (producción)

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1743,6 +1743,33 @@ body.dragging .gallery-item:not(.dragging):hover {
   gap: 8px;
 }
 
+.album-edit-btn {
+  background: rgba(33, 150, 243, 0.2);
+  border: 1px solid rgba(33, 150, 243, 0.35);
+  color: #2196f3;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  transition: all 0.3s ease;
+  opacity: 1;
+}
+
+.album-item:hover .album-edit-btn {
+  opacity: 1;
+}
+
+.album-edit-btn:hover {
+  background: rgba(33, 150, 243, 0.85);
+  color: white;
+  transform: scale(1.1);
+  box-shadow: 0 2px 8px rgba(33,150,243,0.4);
+}
+
 .album-delete-btn {
   background: rgba(220, 53, 69, 0.2);
   border: 1px solid rgba(220, 53, 69, 0.3);

--- a/public/js/albums.js
+++ b/public/js/albums.js
@@ -195,6 +195,9 @@ class AlbumsManager {
                 <h4 class="album-name">${album.name}</h4>
                 <div class="album-actions">
                     <span class="album-count">${album.images ? album.images.length : 0}</span>
+                    <button class="album-edit-btn" title="Editar álbum">
+                        <i class="fas fa-pen"></i>
+                    </button>
                     <button class="album-delete-btn" title="Eliminar álbum">
                         <i class="fas fa-trash"></i>
                     </button>
@@ -224,6 +227,15 @@ class AlbumsManager {
             deleteBtn.addEventListener('click', (e) => {
                 e.stopPropagation();
                 this.deleteAlbum(album.id);
+            });
+        }
+
+        // Event listener para el botón de editar (accesible sin doble clic)
+        const editBtn = albumDiv.querySelector('.album-edit-btn');
+        if (editBtn) {
+            editBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                this.editAlbum(album);
             });
         }
 

--- a/tests/admin.albums.edit.spec.ts
+++ b/tests/admin.albums.edit.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { apiLogin } from './utils/auth';
+
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+
+test.describe('Admin - Álbumes (edición básica)', () => {
+  test('Crear y editar un álbum (nombre y slug) persiste', async ({ page }) => {
+    if (!ADMIN_PASSWORD) test.skip(true, 'ADMIN_PASSWORD no configurado');
+    test.slow();
+
+    await apiLogin(page, ADMIN_PASSWORD);
+    await page.goto('/admin');
+
+    // Crear álbum
+    await page.getByRole('button', { name: /nuevo álbum/i }).click();
+    await page.getByLabel(/nombre del álbum/i).fill('RC Edit Test');
+    await page.getByLabel(/descripción/i).fill('desc original');
+    await page.getByRole('button', { name: /guardar/i }).click();
+    await expect(page.locator('#albums-list .album-item')).toContainText('RC Edit Test');
+
+    // Abrir modal de edición usando el botón de editar
+    const created = page.locator('#albums-list .album-item').filter({ hasText: 'RC Edit Test' });
+    await created.locator('.album-edit-btn').click();
+
+    // Editar nombre y slug
+    await page.getByLabel(/nombre del álbum/i).fill('RC Editado');
+    const slug = page.getByLabel(/slug/i);
+    await slug.fill('rc-editado');
+    await page.getByRole('button', { name: /guardar/i }).click();
+
+    // Verificar en UI
+    await expect(page.locator('#albums-list .album-item')).toContainText('RC Editado');
+
+    // Verificar por API que exista con slug actualizado
+    const res = await page.request.get('/api/albums');
+    const list = await res.json();
+    const found = Array.isArray(list) && list.find((a: any) => a.name === 'RC Editado' && a.slug === 'rc-editado');
+    expect(Boolean(found)).toBeTruthy();
+  });
+});
+
+

--- a/views/admin.html
+++ b/views/admin.html
@@ -20,6 +20,7 @@
             </div>
             <div class="nav-menu">
                 <a href="#cover-photos" class="nav-link">Portada</a>
+                <a href="#albums" class="nav-link">Álbumes</a>
                 <a href="#gallery" class="nav-link" id="gallery-nav-btn">Galería</a>
                 <a href="#upload" class="nav-link">Subir Fotos</a>
                 <a href="#metrics" class="nav-link">Métricas</a>
@@ -103,6 +104,9 @@
 
     <!-- Contenido principal -->
     <main class="main-content" id="main-content">
+        <!-- Anchor para scroll a Álbumes desde navbar -->
+        <span id="albums"></span>
+        
         <!-- Cover Section (Portada grande) -->
         <section id="cover-photos" class="cover-section">
             <div class="container">


### PR DESCRIPTION
Este PR integra la RC v1.17.1 a main.

Cambios principales:
- Portada/Hero: estado determinístico con KV+Blob, sin fallbacks /uploads, auto-refresh 30s, logs con RID. Borde azul en Admin.
- Álbumes: botón visible de edición en lista, modal mejorado, verificación de persistencia.
- Tests: Playwright  para crear/editar álbum y  estabilizado.
- Navbar Admin: enlace directo a Álbumes.

Checklist:
- [ ] Tests Playwright verdes en CI
- [ ] Validado en Vercel (Home y Admin)
- [ ] README actualizado (Gitflow/RC y Portada/Hero)

Al aprobar, squash/merge a main y taggear v1.17.1 si todo queda OK.