### PR TITLE
Release v1.17.2-rc.1: Álbumes edición/reorder + overlay UX + tests estables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Un portfolio elegante y moderno para modelos de moda, con sistema de gestión de álbumes y galería profesional.
 
-## 🎯 **Novedades Principales v1.17.0 (RC)**
+## 🎯 **Novedades Principales v1.17.2 (RC)**
 
 ### 📊 Métricas en Admin (Issue #13)
 - Backend: `POST /api/metrics/event`, `GET /api/metrics/summary?days=7` con Vercel KV y fallback en memoria.
@@ -21,6 +21,21 @@ Un portfolio elegante y moderno para modelos de moda, con sistema de gestión de
 - Home y Admin con auto-refresh suave cada 30s para mantenerse en línea con KV.
 - `hero-loader` prioriza URL pública de Blob; se eliminó cualquier fallback a `/uploads` para Vercel.
 - Logs de troubleshooting opcionales con RID en `/api/cover`, `/api/hero`, POST `/api/cover` y `/uploads/:filename` (ver "Debug logging opcional" más abajo).
+
+### 📚 Álbumes – Edición y reordenamiento
+- Botón visible “Editar” en cada álbum (además de doble clic).
+- Modal con campos: `name`, `description`, `campaign`, `coverImage`, `featured` y `slug` (autogenerado y editable con unicidad).
+- Selector “Agregar a álbum”: portal al `body` (no se corta), reposicionamiento seguro, marca ✓ si la foto ya pertenece y permite alternar agregar/remover.
+- Reordenamiento: endpoint `PUT /api/albums/reorder` robustecido (acepta `albumsOrder`, `order`, array, form-encoded y querystring). Rutas `/api/albums/:id` ya no interceptan `/reorder`.
+
+### 🎛️ UI/UX
+- Overlay de acciones con mayor contraste, blur y botones responsivos.
+- En Admin, el enlace “Galería” resetea a “Ver todas las fotos” y hace scroll confiable.
+
+### 🧪 QA
+- Tests Playwright estabilizados:
+  - Portada: espera render de `.cover-item` con `expect.poll`.
+  - Álbumes: espera a que el modal esté activo y el input sea visible; limpieza al finalizar.
 
 ### 🔜 Próximo
 - RUM (TTFB/LCP/CLS), navegación lightbox (`next/prev`, dwell), reordenamientos (galería/álbumes), top listas (imágenes/álbumes) y selector 7/30 días.
@@ -61,14 +76,14 @@ Un portfolio elegante y moderno para modelos de moda, con sistema de gestión de
 
 ### 🧭 Gitflow (backup/RC)
 - Ramas `release/*` funcionan como respaldo congelado (Release Candidate).
-- Creadas: `release/v1.17.0` (actual), `release/v1.16.0`, `release/v1.15.0`, `release/v1.14.0`, `release/v1.13.0`.
+- Creadas: `release/v1.17.2-rc.1` (actual), `release/v1.17.0`, `release/v1.16.0`, `release/v1.15.0`, `release/v1.14.0`, `release/v1.13.0`.
 
 #### 📦 Cómo crear una Release Candidate nueva
 ```zsh
 git checkout develop
 git pull origin develop
-git checkout -b release/v1.17.0-rc.1
-git push -u origin release/v1.17.0-rc.1
+git checkout -b release/v1.17.2-rc.1
+git push -u origin release/v1.17.2-rc.1
 ```
 Luego validar en Vercel/CI y, al finalizar, mergear a `main` y taggear.
 


### PR DESCRIPTION
Incluye:\n- Álbumes: botón Editar visible; modal con name/description/campaign/coverImage/featured/slug (unicidad).\n- Selector 'Agregar a álbum': portal al body (sin recortes), ✓ para fotos ya incluidas, toggle agregar/remover.\n- Reorder álbumes: endpoint robustecido y ruteo corregido; UI envía orden por body + query.\n- Overlay acciones: más contraste, blur, responsive.\n- Navbar Admin: 'Galería' resetea y hace scroll confiable.\n- QA: tests Playwright estabilizados (portada y álbumes).\n\nChecklist:\n- [ ] Smoke manual en Vercel (Admin y público).\n- [ ] E2E verdes.\n- [ ] Confirmar que no queden álbumes de test.\n